### PR TITLE
Make Message Writable After It Is Initially Set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ class ExtendableError extends Error {
     // extending Error is weird and does not propagate `message`
     Object.defineProperty(this, 'message', {
       enumerable : false,
-      value : message
+      value : message,
+      writable : true,
     });
 
     Object.defineProperty(this, 'name', {


### PR DESCRIPTION
In Hapi, if an ES6Error is thrown outside of the request/reply lifecycle, Boom will attempt to catch the uncaught error and return a badImplementation. During this process they rewrite the message property to have "Uncaught Error:" in front of it (https://github.com/hapijs/boom/blob/master/lib/index.js#L124)

ES6Error's message isn't writable after initially being said so this causes Boom to throw a TypeError, which will crash the application. 

Making the message writable solves this fatal crash (tested on my local branch)
