### PR TITLE
ES6 exports in jsnext:main

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,7 +6,9 @@ const babel = require('babel-core'),
 // es5 build
 babel.transformFile('./src/index.js', (err, result) => {
   if (err) throw err;
-  fs.writeFile('./lib/index.js', result.code, onWriteCompleted);
+
+  let filename = './lib/index.js';
+  fs.writeFile(filename, result.code, onWriteCompleted(filename));
 });
 
 // jsnext build
@@ -18,9 +20,14 @@ let jsnextOpts = {
 
 babel.transformFile('./src/index.js', jsnextOpts, (err, result) => {
   if (err) throw err;
-  fs.writeFile('./lib/index.jsnext.js', result.code, onWriteCompleted);
+
+  let filename = './lib/index.jsnext.js';
+  fs.writeFile(filename, result.code, onWriteCompleted(filename));
 });
 
-function onWriteCompleted(err) {
-  if (err) throw err;
+function onWriteCompleted(filename) {
+  return err => {
+    if (err) throw err;
+    console.log(`${filename} written`);
+  }
 }

--- a/build.js
+++ b/build.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const babel = require('babel-core'),
+  fs = require('fs');
+
+// es5 build
+babel.transformFile('./src/index.js', (err, result) => {
+  if (err) throw err;
+  fs.writeFile('./lib/index.js', result.code, onWriteCompleted);
+});
+
+// jsnext build
+
+let jsnextOpts = {
+  presets: [ [ 'es2015', { modules: false } ] ],
+  babelrc: false
+};
+
+babel.transformFile('./src/index.js', jsnextOpts, (err, result) => {
+  if (err) throw err;
+  fs.writeFile('./lib/index.jsnext.js', result.code, onWriteCompleted);
+});
+
+function onWriteCompleted(err) {
+  if (err) throw err;
+}

--- a/build.js
+++ b/build.js
@@ -1,33 +1,33 @@
 'use strict';
 
-const babel = require('babel-core'),
+var babel = require('babel-core'),
   fs = require('fs');
 
 // es5 build
-babel.transformFile('./src/index.js', (err, result) => {
+babel.transformFile('./src/index.js', function(err, result) {
   if (err) throw err;
 
-  let filename = './lib/index.js';
+  var filename = './lib/index.js';
   fs.writeFile(filename, result.code, onWriteCompleted(filename));
 });
 
 // jsnext build
 
-let jsnextOpts = {
+var jsnextOpts = {
   presets: [ [ 'es2015', { modules: false } ] ],
   babelrc: false
 };
 
-babel.transformFile('./src/index.js', jsnextOpts, (err, result) => {
+babel.transformFile('./src/index.js', jsnextOpts, function(err, result) {
   if (err) throw err;
 
-  let filename = './lib/index.jsnext.js';
+  var filename = './lib/index.jsnext.js';
   fs.writeFile(filename, result.code, onWriteCompleted(filename));
 });
 
 function onWriteCompleted(filename) {
-  return err => {
+  return function(err) {
     if (err) throw err;
-    console.log(`${filename} written`);
+    console.log(filename + ' written');
   }
 }

--- a/lib/index.jsnext.js
+++ b/lib/index.jsnext.js
@@ -1,40 +1,11 @@
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-function _extendableBuiltin(cls) {
-  function ExtendableBuiltin() {
-    cls.apply(this, arguments);
-  }
-
-  ExtendableBuiltin.prototype = Object.create(cls.prototype, {
-    constructor: {
-      value: cls,
-      enumerable: false,
-      writable: true,
-      configurable: true
-    }
-  });
-
-  if (Object.setPrototypeOf) {
-    Object.setPrototypeOf(ExtendableBuiltin, cls);
-  } else {
-    ExtendableBuiltin.__proto__ = cls;
-  }
-
-  return ExtendableBuiltin;
-}
-
-var ExtendableError = function (_extendableBuiltin2) {
-  _inherits(ExtendableError, _extendableBuiltin2);
+var ExtendableError = function (_Error) {
+  _inherits(ExtendableError, _Error);
 
   function ExtendableError() {
     var message = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
@@ -73,7 +44,6 @@ var ExtendableError = function (_extendableBuiltin2) {
   }
 
   return ExtendableError;
-}(_extendableBuiltin(Error));
+}(Error);
 
-exports.default = ExtendableError;
-module.exports = exports['default'];
+export default ExtendableError;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.0",
   "description": "Easily-extendable error for use with ES6 classes",
   "main": "./lib/index",
-  "jsnext:main": "./lib/index",
+  "jsnext:main": "./lib/index.jsnext.js",
   "typings": "./lib/index.d.ts",
   "scripts": {
     "test": "mocha --compilers js:babel-core/register --recursive",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "typings": "./lib/index.d.ts",
   "scripts": {
     "test": "mocha --compilers js:babel-core/register --recursive",
-    "build": "babel ./src --out-dir ./lib",
+    "build": "node build.js",
     "prepublish": "npm run build && npm run test"
   },
   "repository": {


### PR DESCRIPTION
This is my proposed solution to #25.

From the [Rollup docs](https://github.com/rollup/rollup/wiki/jsnext:main):

> 'jsnext:main' will point to a module that has _ES2015 module syntax_ but otherwise _only syntax features that node supports._

This pull request adds an additional file, `index.jsnext.js` to the lib directory. It is equivilant to `lib/index.js` except that the module exports are left in the ES6 style.

This should be considered a _breaking change_ as the format of the file referred to by `jsnext:main` in package.json has changed.
