### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: node_js
 node_js:
     - "stable"
+    - "14"
+    - "13"
+    - "12"
+    - "11"
+    - "10"
+    - "9"
     - "8"
     - "7"
-    - "6"
-    - "5"
 
+arch:
+    - amd64
+    - ppc64le


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.